### PR TITLE
Fix wallet ffi test

### DIFF
--- a/base_layer/wallet/src/testnet_utils.rs
+++ b/base_layer/wallet/src/testnet_utils.rs
@@ -77,7 +77,7 @@ use tari_crypto::{
 };
 use tari_p2p::{initialization::CommsConfig, transport::TransportType};
 use tari_shutdown::{Shutdown, ShutdownSignal};
-use tokio::time::delay_for;
+use tokio::{runtime::Handle, time::delay_for};
 
 // Used to generate test wallet data
 
@@ -773,7 +773,9 @@ pub async fn receive_test_transaction<
     W: ContactsBackend,
 >(
     wallet: &mut Wallet<T, U, V, W>,
-) -> Result<(), WalletError> {
+    handle: &Handle,
+) -> Result<(), WalletError>
+{
     let contacts = wallet.contacts_service.get_contacts().await.unwrap();
     let (_secret_key, mut public_key): (CommsSecretKey, CommsPublicKey) = PublicKey::random_keypair(&mut OsRng);
 
@@ -787,6 +789,7 @@ pub async fn receive_test_transaction<
             OsRng.next_u64(),
             MicroTari::from(10_000 + OsRng.next_u64() % 101_000),
             public_key,
+            handle,
         )
         .await?;
 

--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -76,7 +76,7 @@ use tari_core::{
 use tari_p2p::domain_message::DomainMessage;
 use tari_service_framework::{reply_channel, reply_channel::Receiver};
 use tari_shutdown::ShutdownSignal;
-use tokio::{sync::broadcast, task::JoinHandle};
+use tokio::{runtime::Handle, sync::broadcast, task::JoinHandle};
 
 const LOG_TARGET: &str = "wallet::transaction_service::service";
 
@@ -509,8 +509,9 @@ where
                 Ok(TransactionServiceResponse::FinalizedPendingInboundTransaction)
             },
             #[cfg(feature = "test_harness")]
-            TransactionServiceRequest::AcceptTestTransaction((tx_id, amount, source_pubkey)) => {
-                self.receive_test_transaction(tx_id, amount, source_pubkey).await?;
+            TransactionServiceRequest::AcceptTestTransaction((tx_id, amount, source_pubkey, handle)) => {
+                self.receive_test_transaction(tx_id, amount, source_pubkey, handle)
+                    .await?;
                 Ok(TransactionServiceResponse::AcceptedTestTransaction)
             },
             #[cfg(feature = "test_harness")]
@@ -1712,6 +1713,7 @@ where
         _tx_id: TxId,
         amount: MicroTari,
         source_public_key: CommsPublicKey,
+        handle: Handle,
     ) -> Result<(), TransactionServiceError>
     {
         use crate::{
@@ -1726,8 +1728,6 @@ where
         };
         use futures::stream;
         use tari_core::consensus::{ConsensusConstantsBuilder, Network};
-        use tari_shutdown::Shutdown;
-        use tokio::runtime::Runtime;
 
         let (_sender, receiver) = reply_channel::unbounded();
         let (tx, _rx) = mpsc::channel(20);
@@ -1736,15 +1736,14 @@ where
         let (event_publisher, _) = broadcast::channel(100);
         let ts_handle = TransactionServiceHandle::new(ts_request_sender, event_publisher.clone());
         let constants = ConsensusConstantsBuilder::new(Network::Stibbons).build();
-        let shutdown = Shutdown::new();
+        let shutdown_signal = self.resources.shutdown_signal.clone();
         let (sender, receiver_bns) = reply_channel::unbounded();
         let (event_publisher_bns, _) = broadcast::channel(100);
 
-        let runtime = Runtime::new().map_err(|e| TransactionServiceError::TestHarnessError(e.to_string()))?;
         let basenode_service_handle = BaseNodeServiceHandle::new(sender, event_publisher_bns);
-        let mut mock_base_node_service = MockBaseNodeService::new(receiver_bns, shutdown.to_signal());
+        let mut mock_base_node_service = MockBaseNodeService::new(receiver_bns, shutdown_signal.clone());
         mock_base_node_service.set_default_base_node_state();
-        runtime.spawn(mock_base_node_service.run());
+        handle.spawn(mock_base_node_service.run());
         let mut fake_oms = OutputManagerService::new(
             OutputManagerServiceConfig::default(),
             OutboundMessageRequester::new(tx),
@@ -1755,7 +1754,7 @@ where
             oms_event_publisher,
             self.resources.factories.clone(),
             constants,
-            shutdown.to_signal(),
+            shutdown_signal,
             basenode_service_handle,
         )
         .await?;


### PR DESCRIPTION
Creating a new runtime inside the transaction service was causing a
tokio panic, this passes the wallet runtime handle through to
`receive_test_transaction`. Tests should pass. 
