### PR TITLE
Updated zero-conf test with a complex transaction map

### DIFF
--- a/base_layer/core/src/mempool/mempool_storage.rs
+++ b/base_layer/core/src/mempool/mempool_storage.rs
@@ -49,8 +49,6 @@ pub struct MempoolStorage {
     validator: Arc<dyn MempoolTransactionValidation>,
 }
 
-
-
 impl MempoolStorage {
     /// Create a new Mempool with an UnconfirmedPool and ReOrgPool.
     pub fn new(config: MempoolConfig, validators: Arc<dyn MempoolTransactionValidation>) -> Self {

--- a/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
+++ b/base_layer/core/src/mempool/unconfirmed_pool/unconfirmed_pool.rs
@@ -272,7 +272,10 @@ impl UnconfirmedPool {
             .transaction
             .first_kernel_excess_sig()
             .ok_or(UnconfirmedPoolError::TransactionNoKernels)?;
-        if required_transactions.insert(key.clone(), (*transaction).clone()).is_none() {
+        if required_transactions
+            .insert(key.clone(), (*transaction).clone())
+            .is_none()
+        {
             *total_weight += transaction.weight;
         };
         Ok(())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This transaction graph will be created, containing 3 levels of zero-conf transactions, inheriting dependent

```
    // outputs from multiple parents
    //
    // tx01   tx02   tx03   tx04    Basis transactions using mined inputs (lowest fees, increases left to right)
    //   | \    |      |      |
    //   |  \   |      |      |
    //   |   \  |      |      |
    // tx11   tx12   tx13   tx14    Zero-conf level 1 transactions (fees up from previous, increases left to right)
    //   | \    | \    |   /  |
    //   |  |   |  \   |  |   |
    //   |  |   |   \  |  |   |
    // tx21 | tx22   tx23 | tx24    Zero-conf level 2 transactions (fees up from previous, increases left to right)
    //   |  |   |      |  |   |
    //   |   \  |      | /    |
    //   |    \ |      |/     |
    // tx31   tx32   tx33   tx34    Zero-conf level 3 transactions (highest fees, increases left to right)
```

