### PR TITLE
feat: consistent metadata signature use

### DIFF
--- a/base_layer/core/src/transactions/coinbase_builder.rs
+++ b/base_layer/core/src/transactions/coinbase_builder.rs
@@ -241,7 +241,7 @@ where TKeyManagerInterface: BaseLayerKeyManagerInterface
         let minimum_value_promise = MicroTari::zero();
 
         let output_version = TransactionOutputVersion::get_current_version();
-        let metadata_message = TransactionOutput::build_metadata_signature_message(
+        let metadata_message = TransactionOutput::metadata_signature_message_from_parts(
             &output_version,
             &script,
             &output_features,

--- a/base_layer/core/tests/tests/block_validation.rs
+++ b/base_layer/core/tests/tests/block_validation.rs
@@ -290,22 +290,22 @@ async fn test_orphan_validator() {
 
     let (tx01, _) = spend_utxos(
         txn_schema!(from: vec![outputs[1].clone()], to: vec![20_000 * uT], fee: 10*uT, lock: 0, features:
-OutputFeatures::default()),
+        OutputFeatures::default()),
     )
     .await;
     let (tx02, _) = spend_utxos(
         txn_schema!(from: vec![outputs[2].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features:
-OutputFeatures::default()),
+        OutputFeatures::default()),
     )
     .await;
     let (tx03, _) = spend_utxos(
         txn_schema!(from: vec![outputs[3].clone()], to: vec![40_000 * uT], fee: 20*uT, lock: 0, features:
-OutputFeatures::default()),
+        OutputFeatures::default()),
     )
     .await;
     let (tx04, _) = spend_utxos(
         txn_schema!(from: vec![outputs[3].clone()], to: vec![50_000 * uT], fee: 20*uT, lock: 2, features:
-OutputFeatures::default()),
+        OutputFeatures::default()),
     )
     .await;
     let (template, _) =


### PR DESCRIPTION
Description
---
Removed helper functions in transaction output in lieu of directly using the methods provided in the core key manager

Motivation and Context
---
Part of core key manager refactoring

How Has This Been Tested?
---
Still WIP

What process can a PR reviewer use to test or verify this change?
---
Inspection

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
