### PR TITLE
fix: review comments

### DIFF
--- a/base_layer/wallet/src/transaction_service/service.rs
+++ b/base_layer/wallet/src/transaction_service/service.rs
@@ -1478,7 +1478,7 @@ where
         let mut input_keys = PublicKey::default();
         for input in transaction.transaction.body.inputs() {
             let context = ScriptContext::new(
-                0,
+                self.last_seen_tip_height.unwrap_or(0),
                 &[0; 32],
                 input
                     .commitment()


### PR DESCRIPTION
Description
---
With `FaucetSpendAggregateUtxo`, validate the aggregate signatures and script offset before updating the database.

Review comments for https://github.com/tari-project/tari/pull/6389.

Motivation and Context
---
If not any small input error here will invalidate the transaction and the entire ceremony will have to be re-run.

How Has This Been Tested?
---
System-level testing.

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
